### PR TITLE
Add narration controls to individual components

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -12,6 +12,7 @@ import 'utils/user_cards.dart';
 import 'utils/app_route.dart';
 import 'utils/sidebar.dart';
 import 'utils/tts_utils.dart';
+import 'widgets/narration_toggle_button.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -22,6 +23,8 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage>
     with SingleTickerProviderStateMixin {
+  static const String _pageNarrationId = 'home_page_overview';
+
   bool isSidebarOpen = false;
   final Duration duration = const Duration(milliseconds: 300);
 
@@ -29,6 +32,7 @@ class _HomePageState extends State<HomePage>
   bool isLoading = true;
   final FlutterTts _tts = FlutterTts();
   bool _isSpeaking = false;
+  String? _activeNarrationId;
 
   @override
   void initState() {
@@ -51,22 +55,27 @@ class _HomePageState extends State<HomePage>
         setState(() => _isSpeaking = true);
       }
     });
-    _tts.setCompletionHandler(() {
-      if (mounted) {
-        setState(() => _isSpeaking = false);
-      }
-    });
-    _tts.setCancelHandler(() {
-      if (mounted) {
-        setState(() => _isSpeaking = false);
-      }
-    });
-    _tts.setPauseHandler(() {
-      if (mounted) {
-        setState(() => _isSpeaking = false);
-      }
+    _tts.setCompletionHandler(_handleSpeechStopped);
+    _tts.setCancelHandler(_handleSpeechStopped);
+    _tts.setPauseHandler(_handleSpeechStopped);
+  }
+
+  void _handleSpeechStopped() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isSpeaking = false;
+      _activeNarrationId = null;
     });
   }
+
+  Future<void> _stopNarration() async {
+    await _tts.stop();
+    _handleSpeechStopped();
+  }
+
+  bool _isNarrating(String id) => _isSpeaking && _activeNarrationId == id;
 
   Future<void> _configureVoice() async {
     await _tts.setVolume(1.0);
@@ -81,6 +90,53 @@ class _HomePageState extends State<HomePage>
       defaultLanguage: 'en-US',
     );
     await configureTtsVoice(_tts, languageCode, locale: Get.locale);
+  }
+
+  Future<void> _speakNarration(String id, String narration) async {
+    final text = narration.trim();
+    if (text.isEmpty) {
+      return;
+    }
+
+    if (_isNarrating(id)) {
+      await _stopNarration();
+      return;
+    }
+
+    await _stopNarration();
+    await _configureVoice();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _activeNarrationId = id;
+      _isSpeaking = true;
+    });
+
+    await _tts.speak(text);
+  }
+
+  String _cardNarrationId(Map<String, dynamic> card) {
+    return (card['route'] as String?) ?? card['title'].toString();
+  }
+
+  String _buildCardNarration(Map<String, dynamic> card) {
+    final buffer = StringBuffer();
+    buffer.writeln(card['title'].toString().tr);
+    final summaryKey = card['summary'] as String?;
+    if (summaryKey != null) {
+      buffer.writeln(summaryKey.tr);
+    } else {
+      buffer.writeln('home_card_hint'.tr);
+    }
+    return buffer.toString();
+  }
+
+  Future<void> _toggleCardNarration(Map<String, dynamic> card) async {
+    final narration = _buildCardNarration(card);
+    final id = _cardNarrationId(card);
+    await _speakNarration(id, narration);
   }
 
   String _buildNarration(List<Map<String, dynamic>> cards) {
@@ -107,18 +163,8 @@ class _HomePageState extends State<HomePage>
   }
 
   Future<void> _toggleNarration(List<Map<String, dynamic>> cards) async {
-    if (_isSpeaking) {
-      await _tts.stop();
-      setState(() => _isSpeaking = false);
-      return;
-    }
-    final narration = _buildNarration(cards).trim();
-    if (narration.isEmpty) {
-      return;
-    }
-    await _configureVoice();
-    setState(() => _isSpeaking = true);
-    await _tts.speak(narration);
+    final narration = _buildNarration(cards);
+    await _speakNarration(_pageNarrationId, narration);
   }
 
   @override
@@ -204,7 +250,7 @@ class _HomePageState extends State<HomePage>
                         onThemeTap: themeController.toggleThemeMode,
                         isDarkMode: themeController.isDarkMode,
                         onNarrationTap: () => _toggleNarration(cards),
-                        isNarrating: _isSpeaking,
+                        isNarrating: _isNarrating(_pageNarrationId),
                       ),
                       body: SafeArea(
                         child: LayoutBuilder(
@@ -293,12 +339,18 @@ class _HomePageState extends State<HomePage>
                                             final summary = summaryKey != null
                                                 ? summaryKey.tr
                                                 : 'home_card_hint'.tr;
+                                            final isCardNarrating =
+                                                _isNarrating(
+                                                    _cardNarrationId(card));
                                             return _DashboardCard(
                                               title:
                                                   card['title'].toString().tr,
                                               icon: icon,
                                               accent: accent,
                                               summary: summary,
+                                              isNarrating: isCardNarrating,
+                                              onNarrationTap: () =>
+                                                  _toggleCardNarration(card),
                                               onTap: () {
                                                 Get.toNamed(
                                                     card['route'] as String);
@@ -703,6 +755,8 @@ class _DashboardCard extends StatefulWidget {
   final Color accent;
   final VoidCallback onTap;
   final String summary;
+  final VoidCallback onNarrationTap;
+  final bool isNarrating;
 
   const _DashboardCard({
     required this.title,
@@ -710,6 +764,8 @@ class _DashboardCard extends StatefulWidget {
     required this.accent,
     required this.onTap,
     required this.summary,
+    required this.onNarrationTap,
+    required this.isNarrating,
   });
 
   @override
@@ -799,6 +855,13 @@ class _DashboardCardState extends State<_DashboardCard> {
                 fontWeight: FontWeight.w600,
                 fontSize: isCompact ? 11.0 : null,
               );
+              final narrationOffset = math.max(contentPadding - 6.0, 8.0);
+              final narrationButtonSize =
+                  isTight ? 34.0 : isCompact ? 38.0 : 44.0;
+              final narrationButtonPadding =
+                  isTight ? 6.0 : isCompact ? 7.0 : 8.0;
+              final narrationIconSize =
+                  isTight ? 18.0 : isCompact ? 20.0 : 22.0;
 
               return Stack(
                 children: [
@@ -812,6 +875,22 @@ class _DashboardCardState extends State<_DashboardCard> {
                         shape: BoxShape.circle,
                         color: Colors.white.withOpacity(0.08),
                       ),
+                    ),
+                  ),
+                  Positioned(
+                    top: narrationOffset,
+                    right: narrationOffset,
+                    child: NarrationToggleButton(
+                      isActive: widget.isNarrating,
+                      onPressed: widget.onNarrationTap,
+                      backgroundColor:
+                          theme.colorScheme.onPrimary.withOpacity(0.16),
+                      iconColor: theme.colorScheme.onPrimary,
+                      size: narrationButtonSize,
+                      padding: EdgeInsets.all(narrationButtonPadding),
+                      iconSize: narrationIconSize,
+                      startTooltip: 'home_listen_start'.tr,
+                      stopTooltip: 'home_listen_stop'.tr,
                     ),
                   ),
                   Padding(

--- a/lib/utils/detail_page.dart
+++ b/lib/utils/detail_page.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:corn_farming/controller/theme_controller.dart';
 import 'package:corn_farming/utils/corn_header.dart';
 import 'package:corn_farming/utils/tts_utils.dart';
+import 'package:corn_farming/widgets/narration_toggle_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:get/get.dart';
@@ -83,9 +84,14 @@ class CornDetailPage extends StatefulWidget {
 }
 
 class _CornDetailPageState extends State<CornDetailPage> {
+  static const String _pageNarrationId = 'detail_page_overview';
+  static const String _introNarrationId = 'detail_intro';
+  static const String _resourcesNarrationId = 'detail_resources';
+
   final FlutterTts _tts = FlutterTts();
   YoutubePlayerController? _youtubeController;
   bool _isSpeaking = false;
+  String? _activeNarrationId;
 
   @override
   void initState() {
@@ -111,22 +117,27 @@ class _CornDetailPageState extends State<CornDetailPage> {
         setState(() => _isSpeaking = true);
       }
     });
-    _tts.setCompletionHandler(() {
-      if (mounted) {
-        setState(() => _isSpeaking = false);
-      }
-    });
-    _tts.setCancelHandler(() {
-      if (mounted) {
-        setState(() => _isSpeaking = false);
-      }
-    });
-    _tts.setPauseHandler(() {
-      if (mounted) {
-        setState(() => _isSpeaking = false);
-      }
+    _tts.setCompletionHandler(_handleSpeechStopped);
+    _tts.setCancelHandler(_handleSpeechStopped);
+    _tts.setPauseHandler(_handleSpeechStopped);
+  }
+
+  void _handleSpeechStopped() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isSpeaking = false;
+      _activeNarrationId = null;
     });
   }
+
+  Future<void> _stopNarration() async {
+    await _tts.stop();
+    _handleSpeechStopped();
+  }
+
+  bool _isNarrating(String id) => _isSpeaking && _activeNarrationId == id;
 
   Future<void> _configureVoice() async {
     await _tts.setVolume(1.0);
@@ -144,6 +155,114 @@ class _CornDetailPageState extends State<CornDetailPage> {
     final speechRate = localeCode == 'bn' ? 0.9 : 0.75;
     await _tts.setSpeechRate(speechRate);
     await _tts.setPitch(1.0);
+  }
+
+  Future<void> _speakNarration(String id, String narration) async {
+    final text = narration.trim();
+    if (text.isEmpty) {
+      return;
+    }
+
+    if (_isNarrating(id)) {
+      await _stopNarration();
+      return;
+    }
+
+    await _stopNarration();
+    await _configureVoice();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _activeNarrationId = id;
+      _isSpeaking = true;
+    });
+
+    await _tts.speak(text);
+  }
+
+  String _sectionNarrationId(CornDetailSection section) =>
+      'detail_section_${section.titleKey}';
+
+  String _timelineNarrationId(CornTimelineItem item) =>
+      'detail_timeline_${item.titleKey}';
+
+  String _videoNarrationId(String? videoId) =>
+      'detail_video_${videoId ?? 'primary'}';
+
+  String _buildIntroNarration() {
+    final buffer = StringBuffer();
+    buffer.writeln(widget.titleKey.tr);
+    buffer.writeln(widget.introKey.tr);
+    if (widget.quickTipKeys.isNotEmpty) {
+      buffer.writeln('detail_quick_tip_heading'.tr);
+      for (final tip in widget.quickTipKeys) {
+        buffer.writeln('- ${tip.tr}');
+      }
+    }
+    return buffer.toString();
+  }
+
+  String _buildSectionNarration(CornDetailSection section) {
+    final buffer = StringBuffer();
+    buffer.writeln(section.titleKey.tr);
+    buffer.writeln(section.descriptionKey.tr);
+    for (final highlight in section.highlightKeys) {
+      buffer.writeln(highlight.tr);
+    }
+    return buffer.toString();
+  }
+
+  String _buildTimelineNarration(CornTimelineItem item) {
+    return '${item.titleKey.tr}. ${item.detailKey.tr}';
+  }
+
+  String _buildResourceNarration() {
+    if (widget.resourceKeys.isEmpty) {
+      return '';
+    }
+    final buffer = StringBuffer();
+    buffer.writeln('detail_resources_title'.tr);
+    for (final resource in widget.resourceKeys) {
+      buffer.writeln(resource.tr);
+    }
+    return buffer.toString();
+  }
+
+  String _buildVideoNarration(String title, String caption) {
+    final buffer = StringBuffer();
+    buffer.writeln(title);
+    buffer.writeln(caption);
+    return buffer.toString();
+  }
+
+  Future<void> _toggleIntroNarration() async {
+    final narration = _buildIntroNarration();
+    await _speakNarration(_introNarrationId, narration);
+  }
+
+  Future<void> _toggleSectionNarration(CornDetailSection section) async {
+    final narration = _buildSectionNarration(section);
+    await _speakNarration(_sectionNarrationId(section), narration);
+  }
+
+  Future<void> _toggleTimelineNarration(CornTimelineItem item) async {
+    final narration = _buildTimelineNarration(item);
+    await _speakNarration(_timelineNarrationId(item), narration);
+  }
+
+  Future<void> _toggleResourceNarration() async {
+    final narration = _buildResourceNarration();
+    if (narration.isEmpty) {
+      return;
+    }
+    await _speakNarration(_resourcesNarrationId, narration);
+  }
+
+  Future<void> _toggleVideoNarration(String title, String caption) async {
+    final narration = _buildVideoNarration(title, caption);
+    await _speakNarration(_videoNarrationId(widget.videoId), narration);
   }
 
   String _buildNarration() {
@@ -179,18 +298,8 @@ class _CornDetailPageState extends State<CornDetailPage> {
   }
 
   Future<void> _toggleNarration() async {
-    if (_isSpeaking) {
-      await _tts.stop();
-      setState(() => _isSpeaking = false);
-      return;
-    }
-    final narration = _buildNarration().trim();
-    if (narration.isEmpty) {
-      return;
-    }
-    await _configureVoice();
-    setState(() => _isSpeaking = true);
-    await _tts.speak(narration);
+    final narration = _buildNarration();
+    await _speakNarration(_pageNarrationId, narration);
   }
 
   @override
@@ -210,7 +319,7 @@ class _CornDetailPageState extends State<CornDetailPage> {
           appBar: _CornDetailAppBar(
             title: widget.titleKey.tr,
             accentIcon: widget.accentIcon,
-            isNarrating: _isSpeaking,
+            isNarrating: _isNarrating(_pageNarrationId),
             onBack: () => Navigator.of(context).maybePop(),
             onNarrationTap: _toggleNarration,
             onThemeTap: themeController.toggleThemeMode,
@@ -298,13 +407,30 @@ class _CornDetailPageState extends State<CornDetailPage> {
                                     .map((tip) => tip.tr)
                                     .toList(),
                                 accentIcon: widget.accentIcon,
+                                onNarrationTap: _toggleIntroNarration,
+                                isNarrating: _isNarrating(_introNarrationId),
                               ),
                               if (_youtubeController != null) ...[
                                 SizedBox(height: spacing + 8),
-                                _VideoCard(
-                                  controller: _youtubeController!,
-                                  title: 'detail_video_title'.tr,
-                                  caption: 'detail_video_hint'.tr,
+                                Builder(
+                                  builder: (context) {
+                                    final videoTitle =
+                                        'detail_video_title'.tr;
+                                    final videoCaption =
+                                        'detail_video_hint'.tr;
+                                    return _VideoCard(
+                                      controller: _youtubeController!,
+                                      title: videoTitle,
+                                      caption: videoCaption,
+                                      isNarrating: _isNarrating(
+                                          _videoNarrationId(widget.videoId)),
+                                      onNarrationTap: () =>
+                                          _toggleVideoNarration(
+                                        videoTitle,
+                                        videoCaption,
+                                      ),
+                                    );
+                                  },
                                 ),
                               ],
                               SizedBox(height: spacing + 4),
@@ -319,6 +445,11 @@ class _CornDetailPageState extends State<CornDetailPage> {
                                             : sectionWidth,
                                         child: _DetailSectionCard(
                                           section: section,
+                                          isNarrating: _isNarrating(
+                                              _sectionNarrationId(section)),
+                                          onNarrationTap: () =>
+                                              _toggleSectionNarration(
+                                                  section),
                                         ),
                                       ),
                                     )
@@ -353,7 +484,14 @@ class _CornDetailPageState extends State<CornDetailPage> {
                                           width: timelineTwoColumn
                                               ? timelineWidth
                                               : safeWidth,
-                                          child: _TimelineCard(item: entry),
+                                          child: _TimelineCard(
+                                            item: entry,
+                                            isNarrating: _isNarrating(
+                                                _timelineNarrationId(entry)),
+                                            onNarrationTap: () =>
+                                                _toggleTimelineNarration(
+                                                    entry),
+                                          ),
                                         ),
                                       )
                                       .toList(),
@@ -365,6 +503,9 @@ class _CornDetailPageState extends State<CornDetailPage> {
                                   resources: widget.resourceKeys
                                       .map((key) => key.tr)
                                       .toList(),
+                                  isNarrating:
+                                      _isNarrating(_resourcesNarrationId),
+                                  onNarrationTap: _toggleResourceNarration,
                                 ),
                               ],
                               SizedBox(height: spacing * 2.4),
@@ -560,11 +701,15 @@ class _IntroCard extends StatelessWidget {
   final String intro;
   final List<String> quickTips;
   final IconData accentIcon;
+  final VoidCallback onNarrationTap;
+  final bool isNarrating;
 
   const _IntroCard({
     required this.intro,
     required this.quickTips,
     required this.accentIcon,
+    required this.onNarrationTap,
+    required this.isNarrating,
   });
 
   @override
@@ -611,11 +756,32 @@ class _IntroCard extends StatelessWidget {
             ),
           );
 
+          final buttonSize = isCompact ? 40.0 : 44.0;
+          final buttonPadding = isCompact ? 8.0 : 10.0;
+          final buttonIconSize = isCompact ? 20.0 : 22.0;
+          final listenButton = NarrationToggleButton(
+            isActive: isNarrating,
+            onPressed: onNarrationTap,
+            backgroundColor: Colors.white.withOpacity(0.22),
+            iconColor: Colors.white,
+            size: buttonSize,
+            padding: EdgeInsets.all(buttonPadding),
+            iconSize: buttonIconSize,
+            startTooltip: 'detail_listen'.tr,
+            stopTooltip: 'detail_stop_listening'.tr,
+          );
+
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               if (isCompact) ...[
-                iconBadge,
+                Row(
+                  children: [
+                    iconBadge,
+                    const Spacer(),
+                    listenButton,
+                  ],
+                ),
                 const SizedBox(height: 14),
                 introText,
               ] else
@@ -625,6 +791,8 @@ class _IntroCard extends StatelessWidget {
                     iconBadge,
                     const SizedBox(width: 16),
                     Expanded(child: introText),
+                    const SizedBox(width: 12),
+                    listenButton,
                   ],
                 ),
               if (quickTips.isNotEmpty) ...[
@@ -659,8 +827,14 @@ class _IntroCard extends StatelessWidget {
 
 class _DetailSectionCard extends StatelessWidget {
   final CornDetailSection section;
+  final VoidCallback onNarrationTap;
+  final bool isNarrating;
 
-  const _DetailSectionCard({required this.section});
+  const _DetailSectionCard({
+    required this.section,
+    required this.onNarrationTap,
+    required this.isNarrating,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -701,11 +875,34 @@ class _DetailSectionCard extends StatelessWidget {
             ),
           );
 
+          final buttonSize = isCompact ? 38.0 : 42.0;
+          final buttonPadding = isCompact ? 7.0 : 8.0;
+          final buttonIconSize = isCompact ? 18.0 : 20.0;
+          final listenButton = NarrationToggleButton(
+            isActive: isNarrating,
+            onPressed: onNarrationTap,
+            backgroundColor:
+                theme.colorScheme.primary.withOpacity(0.12),
+            iconColor: theme.colorScheme.primary,
+            size: buttonSize,
+            padding: EdgeInsets.all(buttonPadding),
+            iconSize: buttonIconSize,
+            startTooltip: 'detail_listen'.tr,
+            stopTooltip: 'detail_stop_listening'.tr,
+          );
+
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               if (isCompact) ...[
-                iconBadge,
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    iconBadge,
+                    const Spacer(),
+                    listenButton,
+                  ],
+                ),
                 const SizedBox(height: 12),
                 titleWidget,
               ] else
@@ -715,6 +912,8 @@ class _DetailSectionCard extends StatelessWidget {
                     iconBadge,
                     const SizedBox(width: 12),
                     Expanded(child: titleWidget),
+                    const SizedBox(width: 12),
+                    listenButton,
                   ],
                 ),
               const SizedBox(height: 12),
@@ -749,8 +948,14 @@ class _DetailSectionCard extends StatelessWidget {
 
 class _TimelineCard extends StatelessWidget {
   final CornTimelineItem item;
+  final VoidCallback onNarrationTap;
+  final bool isNarrating;
 
-  const _TimelineCard({required this.item});
+  const _TimelineCard({
+    required this.item,
+    required this.onNarrationTap,
+    required this.isNarrating,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -765,6 +970,20 @@ class _TimelineCard extends StatelessWidget {
     final iconColor = isDark
         ? Colors.white
         : theme.colorScheme.primary.withOpacity(0.9);
+    final buttonBackground = isDark
+        ? Colors.white.withOpacity(0.18)
+        : theme.colorScheme.primary.withOpacity(0.14);
+    final listenButton = NarrationToggleButton(
+      isActive: isNarrating,
+      onPressed: onNarrationTap,
+      backgroundColor: buttonBackground,
+      iconColor: iconColor,
+      size: 40,
+      padding: const EdgeInsets.all(8),
+      iconSize: 20,
+      startTooltip: 'detail_listen'.tr,
+      stopTooltip: 'detail_stop_listening'.tr,
+    );
     return Container(
       padding: const EdgeInsets.all(18),
       decoration: BoxDecoration(
@@ -790,6 +1009,8 @@ class _TimelineCard extends StatelessWidget {
                   ),
                 ),
               ),
+              const SizedBox(width: 8),
+              listenButton,
             ],
           ),
           const SizedBox(height: 10),
@@ -851,11 +1072,15 @@ class _VideoCard extends StatelessWidget {
   final YoutubePlayerController controller;
   final String title;
   final String caption;
+  final VoidCallback onNarrationTap;
+  final bool isNarrating;
 
   const _VideoCard({
     required this.controller,
     required this.title,
     required this.caption,
+    required this.onNarrationTap,
+    required this.isNarrating,
   });
 
   @override
@@ -868,6 +1093,17 @@ class _VideoCard extends StatelessWidget {
         progressIndicatorColor: theme.colorScheme.primary,
       ),
       builder: (context, player) {
+        final listenButton = NarrationToggleButton(
+          isActive: isNarrating,
+          onPressed: onNarrationTap,
+          backgroundColor: theme.colorScheme.primary.withOpacity(0.15),
+          iconColor: theme.colorScheme.primary,
+          size: 42,
+          padding: const EdgeInsets.all(8),
+          iconSize: 20,
+          startTooltip: 'detail_listen'.tr,
+          stopTooltip: 'detail_stop_listening'.tr,
+        );
         return Container(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
@@ -908,6 +1144,8 @@ class _VideoCard extends StatelessWidget {
                       ),
                     ),
                   ),
+                  const SizedBox(width: 12),
+                  listenButton,
                 ],
               ),
               const SizedBox(height: 14),
@@ -932,12 +1170,29 @@ class _VideoCard extends StatelessWidget {
 
 class _ResourceList extends StatelessWidget {
   final List<String> resources;
+  final VoidCallback onNarrationTap;
+  final bool isNarrating;
 
-  const _ResourceList({required this.resources});
+  const _ResourceList({
+    required this.resources,
+    required this.onNarrationTap,
+    required this.isNarrating,
+  });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final listenButton = NarrationToggleButton(
+      isActive: isNarrating,
+      onPressed: onNarrationTap,
+      backgroundColor: theme.colorScheme.primary.withOpacity(0.12),
+      iconColor: theme.colorScheme.primary,
+      size: 42,
+      padding: const EdgeInsets.all(8),
+      iconSize: 20,
+      startTooltip: 'detail_listen'.tr,
+      stopTooltip: 'detail_stop_listening'.tr,
+    );
     return Container(
       padding: const EdgeInsets.all(22),
       decoration: BoxDecoration(
@@ -950,12 +1205,21 @@ class _ResourceList extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'detail_resources_title'.tr,
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.w700,
-              color: theme.colorScheme.primary,
-            ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  'detail_resources_title'.tr,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              listenButton,
+            ],
           ),
           const SizedBox(height: 14),
           ...resources.map(

--- a/lib/widgets/narration_toggle_button.dart
+++ b/lib/widgets/narration_toggle_button.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+class NarrationToggleButton extends StatelessWidget {
+  final bool isActive;
+  final VoidCallback onPressed;
+  final Color backgroundColor;
+  final Color iconColor;
+  final String startTooltip;
+  final String stopTooltip;
+  final BorderRadius borderRadius;
+  final double size;
+  final EdgeInsetsGeometry padding;
+  final double iconSize;
+  final Duration animationDuration;
+
+  const NarrationToggleButton({
+    super.key,
+    required this.isActive,
+    required this.onPressed,
+    required this.backgroundColor,
+    required this.iconColor,
+    required this.startTooltip,
+    required this.stopTooltip,
+    this.borderRadius = const BorderRadius.all(Radius.circular(16)),
+    this.size = 44,
+    this.padding = const EdgeInsets.all(8),
+    this.iconSize = 22,
+    this.animationDuration = const Duration(milliseconds: 200),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tooltip = isActive ? stopTooltip : startTooltip;
+    return Semantics(
+      button: true,
+      label: tooltip,
+      child: Container(
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: borderRadius,
+        ),
+        child: IconButton(
+          tooltip: tooltip,
+          onPressed: onPressed,
+          constraints: BoxConstraints.tightFor(width: size, height: size),
+          padding: padding,
+          icon: AnimatedSwitcher(
+            duration: animationDuration,
+            transitionBuilder: (child, animation) => ScaleTransition(
+              scale: animation,
+              child: child,
+            ),
+            child: Icon(
+              isActive ? Icons.stop_rounded : Icons.volume_up_rounded,
+              key: ValueKey<bool>(isActive),
+              color: iconColor,
+              size: iconSize,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable narration toggle button widget shared by home and detail screens
- update the home dashboard to expose per-card narration controls while tracking active speech
- enhance detail pages with narration buttons on intro, sections, timeline, video, and resource components for localized speech playback

## Testing
- not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d32227c90883289421c058ed27e4e1