### PR TITLE
Fix YouTube playback on web

### DIFF
--- a/lib/utils/video_embed_stub.dart
+++ b/lib/utils/video_embed_stub.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/widgets.dart';
+
+Widget buildYoutubeEmbed(String videoId) {
+  return const SizedBox.shrink();
+}

--- a/lib/utils/video_embed_web.dart
+++ b/lib/utils/video_embed_web.dart
@@ -1,0 +1,23 @@
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+import 'dart:ui' as ui;
+
+import 'package:flutter/widgets.dart';
+
+Widget buildYoutubeEmbed(String videoId) {
+  final viewType = 'youtube-embed-$videoId-${DateTime.now().microsecondsSinceEpoch}';
+
+  ui.platformViewRegistry.registerViewFactory(viewType, (int _) {
+    final iframe = html.IFrameElement()
+      ..width = '100%'
+      ..height = '100%'
+      ..src = 'https://www.youtube.com/embed/$videoId?autoplay=0&enablejsapi=1'
+      ..style.border = '0'
+      ..allow =
+          'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+      ..allowFullscreen = true;
+    return iframe;
+  });
+
+  return HtmlElementView(viewType: viewType);
+}


### PR DESCRIPTION
## Summary
- avoid initializing the youtube_player_flutter controller on Flutter Web
- embed the YouTube video with an HtmlElementView when running on the web while reusing the existing card visuals
- keep the original YouTube player for other platforms through a shared card layout helper

## Testing
- not run (Flutter SDK not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d336fa0e588328adf84a5b3ba13dbf