### PR TITLE
Fix Bengali TTS locale fallback

### DIFF
--- a/lib/utils/tts_utils.dart
+++ b/lib/utils/tts_utils.dart
@@ -190,17 +190,26 @@ Future<String> resolveTtsLanguage(
 
   final matchedLanguage = _matchLanguage(availableLanguages, dedupedCandidates);
   if (matchedLanguage != null) {
-    final isSupported = await _isLanguageSupported(tts, matchedLanguage);
-    if (isSupported) {
-      print("Selected TTS language: $matchedLanguage");
-      return matchedLanguage;
-    }
+    final normalizedMatch = matchedLanguage.toLowerCase();
+    final requestedLanguage = locale?.languageCode.toLowerCase();
 
-    // If the engine incorrectly reports support status (common for Bengali on
-    // the web), still prefer the matched language so it can be attempted later.
-    if (matchedLanguage.toLowerCase().startsWith('bn')) {
-      print("Using matched Bengali language despite unsupported status: $matchedLanguage");
-      return matchedLanguage;
+    if (requestedLanguage == 'bn' && !normalizedMatch.startsWith('bn')) {
+      print(
+          "Ignoring matched non-Bengali language $matchedLanguage for Bengali locale");
+    } else {
+      final isSupported = await _isLanguageSupported(tts, matchedLanguage);
+      if (isSupported) {
+        print("Selected TTS language: $matchedLanguage");
+        return matchedLanguage;
+      }
+
+      // If the engine incorrectly reports support status (common for Bengali on
+      // the web), still prefer the matched language so it can be attempted later.
+      if (normalizedMatch.startsWith('bn')) {
+        print(
+            "Using matched Bengali language despite unsupported status: $matchedLanguage");
+        return matchedLanguage;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent Bengali locale resolution from selecting non-Bengali languages reported by the engine
- keep Bengali candidates available even when support checks fail so they can still be attempted

## Testing
- flutter test *(fails: Flutter SDK unavailable in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d34118018c83288de3977c689d6a62