### PR TITLE
Adjust header spacing and refresh theme colors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,7 @@ import 'package:corn_farming/utils/material_color.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  Map<String, Map<String, String>> languages = await dep.init();
+  final Map<String, Map<String, String>> languages = await dep.init();
   runApp(MyApp(languages: languages));
 }
 
@@ -28,106 +28,121 @@ class MyApp extends StatelessWidget {
           builder: (localizationController) {
             final ColorScheme lightScheme = ColorScheme.fromSeed(
               seedColor: customSwatch,
-              primary: customSwatch.shade600,
-              secondary: const Color(0xFFF6B042),
-              surface: const Color(0xFFFDF3D9),
-              background: const Color(0xFFF9F3E5),
+              brightness: Brightness.light,
+              primary: customSwatch.shade500,
+              onPrimary: Colors.white,
+              primaryContainer: customSwatch.shade200,
+              secondary: const Color(0xFFD6A75B),
+              secondaryContainer: const Color(0xFFF0D9A6),
+              surface: const Color(0xFFF4EFE3),
+              background: const Color(0xFFFBF7ED),
             );
+
             final ColorScheme darkScheme = ColorScheme.fromSeed(
               seedColor: customSwatch,
-              primary: customSwatch.shade300,
-              secondary: const Color(0xFFFFD37A),
-              surface: const Color(0xFF1F2A17),
-              background: const Color(0xFF141C10),
               brightness: Brightness.dark,
+              primary: customSwatch.shade300,
+              onPrimary: const Color(0xFF1A220F),
+              primaryContainer: customSwatch.shade700,
+              secondary: const Color(0xFFB48C3A),
+              secondaryContainer: const Color(0xFF745F2C),
+              surface: const Color(0xFF1A2313),
+              background: const Color(0xFF12190C),
             );
+
             return GetMaterialApp(
-          debugShowCheckedModeBanner: false,
-          themeMode: themeController.themeMode,
-          theme: ThemeData(
-            useMaterial3: true,
-            colorScheme: lightScheme,
-            scaffoldBackgroundColor: lightScheme.surface,
-            canvasColor: lightScheme.surface,
-            cardColor: Colors.white,
-            textTheme: Theme.of(context).textTheme.apply(
-                  bodyColor: lightScheme.onBackground,
-                  displayColor: lightScheme.onBackground,
+              debugShowCheckedModeBanner: false,
+              themeMode: themeController.themeMode,
+              theme: ThemeData(
+                useMaterial3: true,
+                colorScheme: lightScheme,
+                scaffoldBackgroundColor: lightScheme.surface,
+                canvasColor: lightScheme.surface,
+                cardColor: lightScheme.surface,
+                textTheme: Theme.of(context).textTheme.apply(
+                      bodyColor: lightScheme.onBackground,
+                      displayColor: lightScheme.onBackground,
+                    ),
+                appBarTheme: AppBarTheme(
+                  elevation: 0,
+                  backgroundColor: Colors.transparent,
+                  foregroundColor: lightScheme.onSurface,
+                  titleTextStyle:
+                      Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: lightScheme.onSurface,
+                          ),
                 ),
-            appBarTheme: AppBarTheme(
-              elevation: 0,
-              backgroundColor: Colors.transparent,
-              foregroundColor: lightScheme.onSurface,
-              titleTextStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    fontWeight: FontWeight.bold,
-                    color: lightScheme.onSurface,
+                cardTheme: CardTheme(
+                  margin: EdgeInsets.zero,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
                   ),
-            ),
-            cardTheme: CardThemeData(
-              margin: const EdgeInsets.all(0),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(24),
-              ),
-              elevation: 8,
-              surfaceTintColor: Colors.transparent,
-            ),
-            inputDecorationTheme: InputDecorationTheme(
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(16),
-                borderSide: BorderSide(color: lightScheme.primary.withOpacity(0.3)),
-              ),
-            ),
-            floatingActionButtonTheme: FloatingActionButtonThemeData(
-              backgroundColor: lightScheme.primary,
-              foregroundColor: lightScheme.onPrimary,
-            ),
-          ),
-          darkTheme: ThemeData(
-            useMaterial3: true,
-            colorScheme: darkScheme,
-            scaffoldBackgroundColor: darkScheme.surface,
-            canvasColor: darkScheme.surface,
-            cardColor: darkScheme.surface,
-            textTheme: Theme.of(context).textTheme.apply(
-                  bodyColor: darkScheme.onBackground,
-                  displayColor: darkScheme.onBackground,
+                  elevation: 8,
+                  surfaceTintColor: Colors.transparent,
                 ),
-            appBarTheme: AppBarTheme(
-              elevation: 0,
-              backgroundColor: Colors.transparent,
-              foregroundColor: darkScheme.onSurface,
-              titleTextStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    fontWeight: FontWeight.bold,
-                    color: darkScheme.onSurface,
+                inputDecorationTheme: InputDecorationTheme(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    borderSide: BorderSide(
+                      color: lightScheme.primary.withOpacity(0.3),
+                    ),
                   ),
-            ),
-            cardTheme: CardThemeData(
-              margin: const EdgeInsets.all(0),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(24),
+                ),
+                floatingActionButtonTheme: FloatingActionButtonThemeData(
+                  backgroundColor: lightScheme.primary,
+                  foregroundColor: lightScheme.onPrimary,
+                ),
               ),
-              elevation: 10,
-            ),
-            inputDecorationTheme: InputDecorationTheme(
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(16),
-                borderSide: BorderSide(color: darkScheme.primary.withOpacity(0.4)),
+              darkTheme: ThemeData(
+                useMaterial3: true,
+                colorScheme: darkScheme,
+                scaffoldBackgroundColor: darkScheme.surface,
+                canvasColor: darkScheme.surface,
+                cardColor: darkScheme.surface,
+                textTheme: Theme.of(context).textTheme.apply(
+                      bodyColor: darkScheme.onBackground,
+                      displayColor: darkScheme.onBackground,
+                    ),
+                appBarTheme: AppBarTheme(
+                  elevation: 0,
+                  backgroundColor: Colors.transparent,
+                  foregroundColor: darkScheme.onSurface,
+                  titleTextStyle:
+                      Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: darkScheme.onSurface,
+                          ),
+                ),
+                cardTheme: CardTheme(
+                  margin: EdgeInsets.zero,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                  elevation: 10,
+                ),
+                inputDecorationTheme: InputDecorationTheme(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    borderSide: BorderSide(
+                      color: darkScheme.primary.withOpacity(0.4),
+                    ),
+                  ),
+                ),
+                floatingActionButtonTheme: FloatingActionButtonThemeData(
+                  backgroundColor: darkScheme.primary,
+                  foregroundColor: darkScheme.onPrimary,
+                ),
               ),
-            ),
-            floatingActionButtonTheme: FloatingActionButtonThemeData(
-              backgroundColor: darkScheme.primary,
-              foregroundColor: darkScheme.onPrimary,
-            ),
-          ),
-          translations: Messages(languages: languages),
-          locale: localizationController.locale,
-          fallbackLocale: Locale(
-            AppConstants.languages[0].languageCode,
-            AppConstants.languages[0].countryCode,
-          ),
-          initialRoute: RouteHelper.getInitialRoute(),
-          getPages: RouteHelper.routes,
-        );
+              translations: Messages(languages: languages),
+              locale: localizationController.locale,
+              fallbackLocale: Locale(
+                AppConstants.languages[0].languageCode,
+                AppConstants.languages[0].countryCode,
+              ),
+              initialRoute: RouteHelper.getInitialRoute(),
+              getPages: RouteHelper.routes,
+            );
           },
         );
       },

--- a/lib/utils/corn_header.dart
+++ b/lib/utils/corn_header.dart
@@ -44,12 +44,12 @@ class CornHeaderShell extends StatelessWidget {
     final isDark = theme.brightness == Brightness.dark;
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      padding: const EdgeInsets.fromLTRB(0, 16, 0, 0),
       child: Container(
         decoration: BoxDecoration(
           boxShadow: [
             BoxShadow(
-              color: theme.colorScheme.primary.withOpacity(0.25),
+              color: theme.colorScheme.primary.withOpacity(0.2),
               blurRadius: 26,
               offset: const Offset(0, 14),
             ),
@@ -64,9 +64,10 @@ class CornHeaderShell extends StatelessWidget {
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 colors: [
-                  theme.colorScheme.primary,
+                  theme.colorScheme.primaryContainer
+                      .withOpacity(isDark ? 0.75 : 0.9),
                   theme.colorScheme.primary
-                      .withOpacity(isDark ? 0.6 : 0.45),
+                      .withOpacity(isDark ? 0.7 : 0.55),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,

--- a/lib/utils/material_color.dart
+++ b/lib/utils/material_color.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 
-Map<int, Color> _colorSwatch = {
-  50: const Color(0xFFF9FBE7),
-  100: const Color(0xFFEFF4C7),
-  200: const Color(0xFFDFEBA0),
-  300: const Color(0xFFCBE176),
-  400: const Color(0xFFB5D652),
-  500: const Color.fromARGB(255, 163, 184, 110),
-  600: const Color(0xFF7FB12B),
-  700: const Color(0xFF649521),
-  800: const Color(0xFF4C761A),
-  900: const Color(0xFF324F12),
+final Map<int, Color> _colorSwatch = {
+  50: const Color(0xFFF5F6EE),
+  100: const Color(0xFFE7ECDA),
+  200: const Color(0xFFCFE0B8),
+  300: const Color(0xFFB7D395),
+  400: const Color(0xFF9EC175),
+  500: const Color(0xFF7F9F54),
+  600: const Color(0xFF6B8745),
+  700: const Color(0xFF566C36),
+  800: const Color(0xFF415128),
+  900: const Color(0xFF2B351B),
 };
 
-MaterialColor customSwatch = MaterialColor(0xFF9CC636, _colorSwatch);
+final MaterialColor customSwatch = MaterialColor(0xFF7F9F54, _colorSwatch);

--- a/lib/utils/sidebar.dart
+++ b/lib/utils/sidebar.dart
@@ -28,6 +28,21 @@ class CustomSidebar extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final isCompact = constraints.maxWidth < 260;
+        final isDark = theme.brightness == Brightness.dark;
+        final gradientColors = isDark
+            ? [
+                theme.colorScheme.surface.withOpacity(0.95),
+                theme.colorScheme.primaryContainer.withOpacity(0.6),
+                theme.colorScheme.secondaryContainer.withOpacity(0.45),
+                theme.colorScheme.secondary.withOpacity(0.4),
+              ]
+            : [
+                theme.colorScheme.primaryContainer.withOpacity(0.95),
+                theme.colorScheme.primary.withOpacity(0.7),
+                theme.colorScheme.secondaryContainer.withOpacity(0.65),
+                theme.colorScheme.secondary.withOpacity(0.55),
+              ];
+
         final navItems = [
           _SidebarItem(
             icon: Icons.notifications_active,
@@ -55,16 +70,11 @@ class CustomSidebar extends StatelessWidget {
             gradient: LinearGradient(
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
-              colors: [
-                theme.colorScheme.primary,
-                theme.colorScheme.primary.withOpacity(0.85),
-                theme.colorScheme.secondary,
-                theme.colorScheme.secondary.withOpacity(0.75),
-              ],
+              colors: gradientColors,
             ),
             boxShadow: [
               BoxShadow(
-                color: theme.colorScheme.primary.withOpacity(0.35),
+                color: theme.colorScheme.primary.withOpacity(0.28),
                 blurRadius: 24,
                 offset: const Offset(6, 12),
               ),


### PR DESCRIPTION
## Summary
- retune the shared material swatch and light/dark color schemes to a softer corn-inspired palette
- keep the header shell edge-to-edge while blending its gradient with the calmer tones
- refresh the sidebar gradient to layer the muted greens and golds for each theme

## Testing
- `flutter test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d366f34a90832884cec880a6118488