### PR TITLE
Adjust app bar spacing and dark gradient

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -485,8 +485,8 @@ class _CornAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final screenWidth = MediaQuery.of(context).size.width;
-    final horizontalPadding = screenWidth < 420 ? 4.0 : 8.0;
-    final verticalPadding = screenWidth < 520 ? 3.0 : 5.0;
+    final horizontalPadding = screenWidth < 420 ? 2.0 : 6.0;
+    final verticalPadding = screenWidth < 520 ? 2.0 : 4.0;
 
     final modeChip = Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),

--- a/lib/utils/corn_header.dart
+++ b/lib/utils/corn_header.dart
@@ -35,13 +35,22 @@ class CornHeaderShell extends StatelessWidget {
     super.key,
     required this.child,
     this.height = 120,
-    this.contentPadding = const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+    this.contentPadding = const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
+    final gradientColors = isDark
+        ? [
+            Color.lerp(theme.colorScheme.primaryContainer, Colors.black, 0.45)!,
+            Color.lerp(theme.colorScheme.primary, Colors.black, 0.6)!,
+          ]
+        : [
+            theme.colorScheme.primaryContainer.withOpacity(0.9),
+            theme.colorScheme.primary.withOpacity(0.55),
+          ];
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(0, 16, 0, 0),
@@ -63,12 +72,7 @@ class CornHeaderShell extends StatelessWidget {
             width: double.infinity,
             decoration: BoxDecoration(
               gradient: LinearGradient(
-                colors: [
-                  theme.colorScheme.primaryContainer
-                      .withOpacity(isDark ? 0.75 : 0.9),
-                  theme.colorScheme.primary
-                      .withOpacity(isDark ? 0.7 : 0.55),
-                ],
+                colors: gradientColors,
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
               ),

--- a/lib/utils/detail_page.dart
+++ b/lib/utils/detail_page.dart
@@ -513,8 +513,8 @@ class _CornDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final screenWidth = MediaQuery.of(context).size.width;
-    final horizontalPadding = screenWidth < 420 ? 16.0 : 20.0;
-    final verticalPadding = screenWidth < 520 ? 12.0 : 16.0;
+    final horizontalPadding = screenWidth < 420 ? 12.0 : 16.0;
+    final verticalPadding = screenWidth < 520 ? 10.0 : 14.0;
     final statusText =
         isNarrating ? 'detail_listening'.tr : 'detail_listen'.tr;
 


### PR DESCRIPTION
## Summary
- tighten the home and detail app bar padding so the header content sits closer to the edges on all screen sizes
- reduce the default CornHeaderShell padding and darken the dark-mode gradient for a truer dark sidebar treatment

## Testing
- flutter analyze *(fails: Flutter CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d369f59e848328aebb55f0b558aa4b